### PR TITLE
add tabs to modals to prevent cluttering

### DIFF
--- a/src/BrewImage.css
+++ b/src/BrewImage.css
@@ -1,0 +1,3 @@
+.brew-images {
+	margin: 0 auto;
+}

--- a/src/BrewModal.css
+++ b/src/BrewModal.css
@@ -18,3 +18,13 @@
 	font-weight: lighter;
 	text-shadow: 2px 2px #6495ED;
 }
+
+.brewery-reviews {
+	margin-top: 10px;
+	padding: 10px;
+}
+
+.brewery-description {
+	margin-top: 15px;
+	margin-bottom: 15px;
+}

--- a/src/BreweryImages.js
+++ b/src/BreweryImages.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Carousel } from 'react-bootstrap';
+import './BrewImage.css';
 
 const BreweryImage = ({brewery}) => {
 	return (
@@ -7,7 +8,7 @@ const BreweryImage = ({brewery}) => {
 			{
 				brewery.photos.map((photo, idx) =>
 					<Carousel.Item key={idx}>
-						<img key={idx} width={600} height={250} src={photo} role="presentation" />
+						<img className="brew-images" key={idx} width={600} height={250} src={photo} role="presentation" />
 					</Carousel.Item>
 				)
 			}

--- a/src/BreweryPage.js
+++ b/src/BreweryPage.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Modal, Button } from 'react-bootstrap';
+import { Modal, Button, Tabs, Tab } from 'react-bootstrap';
 import BreweryImages from './BreweryImages';
 
 const BreweryPage = ({
@@ -15,22 +15,28 @@ const BreweryPage = ({
                 <Modal.Title id="contained-modal-title">{brewery.name}</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-            <div>
-              {brewery.description}
-            </div>
-            <div>
-                <BreweryImages brewery={brewery} />
-            </div>
-            <div>
-              {
-                brewery.reviews.map((review, idx) =>
-                  <div key={`${brewery.name}${idx}`}>
-                    <p>{ review.rating } / 5</p>
-                    <p>{ review.text }</p>
+            <Tabs defaultActiveKey={2} id="brew-tabs">
+              <Tab eventKey={1} title="About">
+                  <div className="brewery-description">
+                    {brewery.description}
                   </div>
-                )
-              }
-            </div>
+                  <div>
+                      <BreweryImages brewery={brewery} />
+                  </div>
+              </Tab>
+              <Tab eventKey={2} title="Reviews">
+                <div className="brewery-reviews">
+                  {
+                    brewery.reviews.map((review, idx) =>
+                      <div key={`${brewery.name}${idx}`}>
+                        <p>{ review.rating } / 5</p>
+                        <p>{ review.text }</p>
+                      </div>
+                    )
+                  }
+                </div>
+              </Tab>
+            </Tabs>
             </Modal.Body>
             <Modal.Footer>
                 <Button onClick={toggle}>Close</Button>


### PR DESCRIPTION
Slightly addresses: https://github.com/Aturberv/NYCBeerMap/issues/17

Pagination was being really annoying, couldn't quite figure it out. I settled for tabs and personally I think it turns out even better than having the modals be paginated, its now easier to navigate the modal. Let me know what you think.